### PR TITLE
De-Moo, make max_depth immutable.

### DIFF
--- a/lib/Module/Loader.pm
+++ b/lib/Module/Loader.pm
@@ -1,12 +1,25 @@
 package Module::Loader;
 
 use 5.006;
-use Moo;
+use strict;
+use warnings;
 use Path::Iterator::Rule;
 use File::Spec::Functions   qw/ catfile splitdir /;
 use Carp                    qw/ croak /;
 
-has 'max_depth' => (is => 'rw');
+sub new
+{
+    my ( $class, @args ) = @_;
+    return bless { ( 1 == @args and ref $args[0] ) ? ( %{$args[0]} ) : ( @args ) }, $class;
+}
+
+sub max_depth
+{
+    my ( $self, @args ) = @_;
+    croak 'max_depth is immutable' if @args;
+    return $self->{max_depth} if exists $self->{max_depth};
+    return;
+}
 
 sub find_modules
 {

--- a/t/02-find-modules.t
+++ b/t/02-find-modules.t
@@ -30,7 +30,7 @@ ok(grep { $_ eq 'Monkey::Plugin::Bonobo::Utilities' } @modules,
 ok(grep { $_ eq 'Monkey::Plugin::Mandrill' } @modules,
    "We should find Monkey::Plugin::Bonobo::Utilities");
 
-$loader->max_depth(1);
+$loader = Module::Loader->new( max_depth => 1 );
 @modules = $loader->find_modules('Monkey::Plugin');
 
 ok(grep { $_ eq 'Monkey::Plugin::Bonobo' } @modules,
@@ -42,7 +42,7 @@ ok(!grep { $_ eq 'Monkey::Plugin::Bonobo::Utilities' } @modules,
 ok(grep { $_ eq 'Monkey::Plugin::Mandrill' } @modules,
    "We should find Monkey::Plugin::Bonobo::Utilities");
 
-$loader->max_depth(0);
+$loader = Module::Loader->new({ max_depth => 0 });
 @modules = $loader->find_modules('Monkey::Plugin');
 
 ok(grep { $_ eq 'Monkey::Plugin::Bonobo' } @modules,


### PR DESCRIPTION
As per @leont's remarks about
- Moo being overkill for this context
- Mutability of state being undesirable

This pull fixes both of those issues.

It occurs to me it may be more desirable to have find_modules have a
parameter directly, instead of it being a constructor attribute.

``` perl
  my $modules = $ml->find_modules('Dist::Zilla', { max_depth => 1 });
```

Which suffers none of the action-at-a-distance problems requiring code
scanning to determine what a function will do, but also has the utility
of being able to pass a depth parameter on a per-query basis.

( The latter quandry is presently made more difficult by enforcing
  immutability )

Footnotes: 
- It seems Github is behind CPAN by a bit, 0.02 isn't on Github yet =)
- There's a bunch of repository quirks like `.gitignore` being missing which I opted not to fix in this pull req (due partially to #1 )
- No `META.json`? :) 
